### PR TITLE
Fix operator workload assignment list

### DIFF
--- a/client/src/components/dashboard/operator-workload-summary.tsx
+++ b/client/src/components/dashboard/operator-workload-summary.tsx
@@ -16,7 +16,7 @@ interface OperatorWorkload {
 }
 
 interface OperatorWorkloadSummaryProps {
-  assignments: Map<number, any>;
+  assignments: any[];
 }
 
 export function OperatorWorkloadSummary({ assignments }: OperatorWorkloadSummaryProps) {
@@ -54,7 +54,7 @@ export function OperatorWorkloadSummary({ assignments }: OperatorWorkloadSummary
     });
 
     // Process assignments to calculate workload using UPH data
-    Array.from(assignments.values()).forEach(assignment => {
+    assignments.forEach(assignment => {
       const operator = operatorMap.get(assignment.operatorId);
       if (operator) {
         operator.totalAssignments++;

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -176,7 +176,7 @@ export default function Dashboard() {
       {/* Main content */}
       <div className="max-w-7xl mx-auto px-6 py-6">
         {/* Operator Workload Summary */}
-        <OperatorWorkloadSummary assignments={assignmentsMap} />
+        <OperatorWorkloadSummary assignments={assignmentsData?.assignments || []} />
         
         <ProductionGrid 
           productionOrders={filteredOrders}


### PR DESCRIPTION
## Summary
- pass assignment list to `OperatorWorkloadSummary` instead of a Map
- iterate assignments directly to correctly aggregate operator MOs

## Testing
- `npm run check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_687958248e04832386bb31752752ff2e